### PR TITLE
fix: UNICWEB-142 hide notes and algorithDerivation if not required

### DIFF
--- a/cypress/e2e/Consultation/PageVariableEntity_1.cy.ts
+++ b/cypress/e2e/Consultation/PageVariableEntity_1.cy.ts
@@ -46,8 +46,7 @@ describe('Page d\'une variable - Vérifier les informations affichées', () => {
   });
 
   it('Panneau Summary - Notes', () => {
-    cy.get('[id="summary"] [class="ant-descriptions-item-label"]').eq(6).contains('Notes').should('exist');
-    cy.get('[id="summary"] [class="ant-descriptions-item-content"]').eq(6).contains('-').should('exist');
+    cy.get('[id="summary"] [class="ant-descriptions-item-label"]').contains('Notes').should('not.exist');
   });
 
   it('Panneau Categories - Headers', () => {

--- a/src/app/variable/[...slug]/page.test.tsx
+++ b/src/app/variable/[...slug]/page.test.tsx
@@ -5,7 +5,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useParams } from 'next/navigation';
 import React from 'react';
 
-import EntityTablePage from '@/app/table/[...slug]/page';
 import EntityVariablePage from '@/app/variable/[...slug]/page';
 import { GET_VARIABLE_ENTITY } from '@/lib/graphql/queries/getVariableEntity.query';
 
@@ -182,8 +181,68 @@ describe('Resource Entity with no data', () => {
       data: {}, //no data
       loading: false,
     });
-    render(<EntityTablePage />);
+    render(<EntityVariablePage />);
     expect(screen.getByText('entities.no_data')).toBeInTheDocument();
+  });
+
+  test("entity should not return 'Notes' and 'Deviation Algorithm' component if not required", () => {
+    jest.clearAllMocks();
+    (useQuery as jest.Mock).mockReturnValue({
+      data: {
+        getVariables: {
+          hits: [
+            {
+              var_name: 'labTestStatus',
+              var_value_type: 'string',
+              // - not present -  var_derivation_algorithm: 'AS IS',
+              var_notes: null, // no notes
+              var_label_fr: 'Statut du test',
+              var_label_en: 'Status of the laboratory test performed',
+              var_created_at: 1723832573323,
+              var_last_update: 1723832573323,
+              resource: {
+                rs_name: 'warehouse',
+                rs_code: 'warehouse',
+              },
+            },
+          ],
+        },
+      },
+      loading: false,
+    });
+    render(<EntityVariablePage />);
+    expect(screen.queryByText('entities.algorithmDerivation')).not.toBeInTheDocument();
+    expect(screen.queryByText('entities.notes')).not.toBeInTheDocument();
+  });
+
+  test("entity should return 'Notes' and 'Deviation Algorithm' component if required", () => {
+    jest.clearAllMocks();
+    (useQuery as jest.Mock).mockReturnValue({
+      data: {
+        getVariables: {
+          hits: [
+            {
+              var_name: 'labTestStatus',
+              var_value_type: 'string',
+              var_derivation_algorithm: 'AS IS',
+              var_notes: 'notes',
+              var_label_fr: 'Statut du test',
+              var_label_en: 'Status of the laboratory test performed',
+              var_created_at: 1723832573323,
+              var_last_update: 1723832573323,
+              resource: {
+                rs_name: 'warehouse',
+                rs_code: 'warehouse',
+              },
+            },
+          ],
+        },
+      },
+      loading: false,
+    });
+    render(<EntityVariablePage />);
+    expect(screen.getByText('entities.algorithmDerivation')).toBeInTheDocument();
+    expect(screen.getByText('entities.notes')).toBeInTheDocument();
   });
 
   test('entity should not return Categories sections if not required', () => {
@@ -216,7 +275,7 @@ describe('Resource Entity with no data', () => {
       },
       loading: false,
     });
-    render(<EntityTablePage />);
+    render(<EntityVariablePage />);
     expect(screen.queryByText('global.categories')).not.toBeInTheDocument();
   });
 });

--- a/src/app/variable/[...slug]/utils/getSummaryDescriptions.tsx
+++ b/src/app/variable/[...slug]/utils/getSummaryDescriptions.tsx
@@ -42,7 +42,7 @@ const getSummaryDescriptions = (lang: LANG, variableEntity?: IVariableEntity): I
     label: intl.get('entities.table.Table'),
     value: variableEntity?.resource?.rs_name ? (
       <Link href={`/table/${variableEntity?.resource?.rs_code}/${variableEntity?.table?.tab_name}`}>
-        {variableEntity?.table.tab_name}
+        {variableEntity?.table?.tab_name}
       </Link>
     ) : (
       TABLE_EMPTY_PLACE_HOLDER
@@ -52,16 +52,24 @@ const getSummaryDescriptions = (lang: LANG, variableEntity?: IVariableEntity): I
     label: intl.get('entities.type'),
     value: variableEntity?.var_value_type ? <Tag>{variableEntity?.var_value_type}</Tag> : TABLE_EMPTY_PLACE_HOLDER,
   },
-  {
-    label: intl.get('entities.algorithmDerivation'),
-    value: variableEntity?.var_derivation_algorithm
-      ? formatDeviationAlgorithm(variableEntity?.var_derivation_algorithm)
-      : TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
-    label: intl.get('entities.notes'),
-    value: variableEntity?.var_notes || TABLE_EMPTY_PLACE_HOLDER,
-  },
+  ...(variableEntity?.var_derivation_algorithm
+    ? [
+        {
+          label: intl.get('entities.algorithmDerivation'),
+          value: variableEntity?.var_derivation_algorithm
+            ? formatDeviationAlgorithm(variableEntity?.var_derivation_algorithm)
+            : TABLE_EMPTY_PLACE_HOLDER,
+        },
+      ]
+    : []),
+  ...(variableEntity?.var_notes
+    ? [
+        {
+          label: intl.get('entities.notes'),
+          value: variableEntity?.var_notes || TABLE_EMPTY_PLACE_HOLDER,
+        },
+      ]
+    : []),
 ];
 
 export default getSummaryDescriptions;


### PR DESCRIPTION
### Page entité variables: Champs à cacher lorsque vide

[UNICWEB-142](https://ferlab-crsj.atlassian.net/browse/UNICWEB-142)

![Screenshot from 2025-03-25 13-40-34](https://github.com/user-attachments/assets/577e6005-6492-4a8c-b084-c24339f58e8b)

--------------------------------------------------

![Screenshot from 2025-03-25 13-40-19](https://github.com/user-attachments/assets/d4c0fde6-9207-402a-8927-483722200822)


[UNICWEB-142]: https://ferlab-crsj.atlassian.net/browse/UNICWEB-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ