### PR TITLE
fix: UNICWEB-202 table entity variable count url fix

### DIFF
--- a/src/app/table/[...slug]/utils/getVariablesDescriptions.tsx
+++ b/src/app/table/[...slug]/utils/getVariablesDescriptions.tsx
@@ -20,6 +20,11 @@ const getVariablesDescriptions = (lang: LANG, tableEntity?: ITableEntity): IEnti
             store.dispatch(
               globalActions.setFilters([
                 { key: 'table.tab_name', values: [tableEntity.tab_name], tabKey: VARIABLES_TAB_KEY },
+                {
+                  key: 'resource.rs_name',
+                  values: [tableEntity.resource?.rs_name || ''],
+                  tabKey: VARIABLES_TAB_KEY,
+                },
               ]),
             )
           }


### PR DESCRIPTION
### [Entity Table] Variable count, wrong link query

[UNICWEB-202](https://ferlab-crsj.atlassian.net/browse/UNICWEB-202)

https://portal-ui-unicweb-202.qa.unic.ferlab.bio/catalog

[UNICWEB-202]: https://ferlab-crsj.atlassian.net/browse/UNICWEB-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


![Screenshot from 2025-04-28 10-10-25](https://github.com/user-attachments/assets/5c26df8f-6da6-423f-a940-e6353a207686)

![Screenshot from 2025-04-28 10-11-03](https://github.com/user-attachments/assets/d3c6f825-5177-491a-8a2c-4049442b503f)

